### PR TITLE
Update dependencies and migrate to Scala Native 0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
         if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 11
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.project }}
           path: targets.tar
@@ -121,7 +121,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -131,7 +131,7 @@ jobs:
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
         if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 11
@@ -144,7 +144,7 @@ jobs:
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -155,7 +155,7 @@ jobs:
         run: sbt +update
 
       - name: Download target directories (2.13, http4sStirJS)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.13-http4sStirJS
 
@@ -165,7 +165,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (2.13, http4sStirNative)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.13-http4sStirNative
 
@@ -175,7 +175,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (2.13, http4sStirJVM)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.13-http4sStirJVM
 
@@ -185,7 +185,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (3, http4sStirJS)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-3-http4sStirJS
 
@@ -195,7 +195,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (3, http4sStirNative)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-3-http4sStirNative
 
@@ -205,7 +205,7 @@ jobs:
           rm targets.tar
 
       - name: Download target directories (3, http4sStirJVM)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-3-http4sStirJVM
 
@@ -248,7 +248,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -258,7 +258,7 @@ jobs:
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
         if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 11
@@ -271,7 +271,7 @@ jobs:
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ ThisBuild / versionScheme := Some("early-semver")
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11"), JavaSpec.temurin("17"))
 ThisBuild / githubWorkflowPublishTargetBranches := Seq(RefPredicate.StartsWith(Ref.Tag("v")),
   RefPredicate.Equals(Ref.Branch("master")))
-ThisBuild / tlBaseVersion := "0.4"
+ThisBuild / tlBaseVersion := "0.5"
 ThisBuild / tlCiHeaderCheck := false
 ThisBuild / publishTo := {
   val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val scala_2_13 = "2.13.18"
-val scala_3 = "3.3.7"
+val scala_3 = "3.3.8"
 val mainScalaVersion = scala_3
 val supportedScalaVersions = Seq(scala_2_13, scala_3)
 
@@ -57,24 +57,24 @@ lazy val baseSettings = Seq(
   crossScalaVersions := supportedScalaVersions,
   scalafmtOnCompile := true)
 
-val http4sDsl = Def.setting("org.http4s" %%% "http4s-dsl" % "0.23.33")
-val http4sEmber = Def.setting("org.http4s" %%% "http4s-ember-server" % "0.23.33")
+val http4sDsl = Def.setting("org.http4s" %%% "http4s-dsl" % "0.23.36")
+val http4sEmber = Def.setting("org.http4s" %%% "http4s-ember-server" % "0.23.36")
 
-val fs2Core = Def.setting("co.fs2" %%% "fs2-core" % "3.12.2")
-val fs2Io = Def.setting("co.fs2" %%% "fs2-io" % "3.12.2")
+val fs2Core = Def.setting("co.fs2" %%% "fs2-core" % "3.13.0")
+val fs2Io = Def.setting("co.fs2" %%% "fs2-io" % "3.13.0")
 
 val http4sClient = Def.setting(
-  "org.http4s" %%% "http4s-ember-client" % "0.23.33")
+  "org.http4s" %%% "http4s-ember-client" % "0.23.36")
 
-val circeCore = Def.setting("io.circe" %%% "circe-core" % "0.14.15")
-val circeGeneric = Def.setting("io.circe" %%% "circe-generic" % "0.14.15")
-val circeParser = Def.setting("io.circe" %%% "circe-parser" % "0.14.15")
-val http4sCirce = Def.setting("org.http4s" %%% "http4s-circe" % "0.23.33")
+val circeCore = Def.setting("io.circe" %%% "circe-core" % "0.14.16")
+val circeGeneric = Def.setting("io.circe" %%% "circe-generic" % "0.14.16")
+val circeParser = Def.setting("io.circe" %%% "circe-parser" % "0.14.16")
+val http4sCirce = Def.setting("org.http4s" %%% "http4s-circe" % "0.23.36")
 
-val scalatest = Def.setting("org.scalatest" %%% "scalatest" % "3.2.19")
-val specs2 = Def.setting("org.specs2" %%% "specs2-core" % "4.20.6")
+val scalatest = Def.setting("org.scalatest" %%% "scalatest" % "3.2.20")
+val specs2 = Def.setting("org.specs2" %%% "specs2-core" % "4.23.0")
 
-val scalaXml = Def.setting("org.scala-lang.modules" %%% "scala-xml" % "2.2.0")
+val scalaXml = Def.setting("org.scala-lang.modules" %%% "scala-xml" % "2.4.0")
 
 lazy val core = crossProject(JVMPlatform, NativePlatform, JSPlatform)
   .withoutSuffixFor(JVMPlatform)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.6
+sbt.version=1.12.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,13 +1,13 @@
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.20.2")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
-addSbtPlugin("org.typelevel" % "sbt-typelevel-ci-release" % "0.8.0")
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.8.2")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")
+addSbtPlugin("org.typelevel" % "sbt-typelevel-ci-release" % "0.8.7")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.9.0")
 addSbtPlugin("org.jmotor.sbt" % "sbt-dependency-updates" % "1.2.9")
 
 libraryDependencySchemes += "com.lihaoyi" %% "geny" % VersionScheme.Always


### PR DESCRIPTION
## Summary

Updates all dependencies and migrates the build from Scala Native 0.4 to **Scala Native 0.5**.

The long-standing blocker for SN 0.5 was http4s itself: the 0.23.x series was published for Native 0.4 only through 0.23.33, then switched to Native 0.5 starting with 0.23.34 — so the http4s update and the SN 0.5 migration go hand in hand. No source changes were needed, and no epollcat-style workarounds are required since cats-effect 3.6 ships an integrated polling system.

### Library updates
- http4s 0.23.33 → 0.23.36 (dsl, ember-server, ember-client, circe)
- fs2 3.12.2 → 3.13.0 (Native 0.5 only from 3.13.0)
- circe 0.14.15 → 0.14.16
- scala-xml 2.2.0 → 2.4.0
- scalatest 3.2.19 → 3.2.20
- specs2 4.20.6 → 4.23.0 (staying on 4.x — specs2 5 dropped Scala 2.13)
- Scala 3.3.7 → 3.3.8 (LTS line; 2.13.18 already latest)

### Toolchain updates
- sbt-scala-native 0.4.17 → 0.5.12
- sbt-scalajs 1.20.2 → 1.22.0
- sbt-typelevel-ci-release 0.8.0 → 0.8.7
- sbt-mdoc 2.8.2 → 2.9.0
- sbt-scalafmt 2.5.6 → 2.6.1
- sbt 1.12.6 → 1.12.13
- `ci.yml` regenerated via `githubWorkflowGenerate` (GitHub Actions version bumps only)

## Test plan
- [x] `+Test/compile` passes for Scala 2.13 and 3.3.8 on JVM, JS, and Native
- [x] `+http4sStirJVM/test` — all 445 tests pass on both Scala versions
- [x] CI `Test/nativeLink` (not runnable locally — no clang on this machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)